### PR TITLE
Add a check for Python 3 at the start of script

### DIFF
--- a/flashtnc.py
+++ b/flashtnc.py
@@ -18,7 +18,9 @@ import serial
 import sys
 import time
 
-assert sys.version_info >= (3, 0), "Python version should be 3.x"
+if sys.version_info < (3, 0): 
+	print("Python version should be 3.x, exiting")
+	sys.exit(2)
 
 def GracefulExit(port, file, code):
 	try:

--- a/flashtnc.py
+++ b/flashtnc.py
@@ -18,6 +18,8 @@ import serial
 import sys
 import time
 
+assert sys.version_info >= (3, 0), "Python version should be 3.x"
+
 def GracefulExit(port, file, code):
 	try:
 		port.close()


### PR DESCRIPTION
This will raise an exception if the Python version is less than 3.0.

Example output:

```
$ python2 flashtnc.py 
Traceback (most recent call last):
  File "flashtnc.py", line 22, in <module>
    assert sys.version_info >= (3, 0), "Python version should be 3.x"
AssertionError: Python version should be 3.x
```